### PR TITLE
don't require store to be mutable to obtain writer for it

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -191,7 +191,7 @@ mod tests {
         fs::create_dir_all(root.path()).expect("dir created");
         let k = Rkv::new(root.path()).expect("new succeeded");
 
-        let mut sk: Store<&str> = k.create_or_open("sk").expect("opened");
+        let sk: Store<&str> = k.create_or_open("sk").expect("opened");
 
         {
             let mut writer = sk.write(&k).expect("writer");
@@ -266,7 +266,7 @@ mod tests {
         let root = TempDir::new("test_isolation").expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
         let k = Rkv::new(root.path()).expect("new succeeded");
-        let mut s: Store<&str> = k.create_or_open("s").expect("opened");
+        let s: Store<&str> = k.create_or_open("s").expect("opened");
 
         // Add one field.
         {

--- a/src/readwrite.rs
+++ b/src/readwrite.rs
@@ -114,7 +114,7 @@ impl<K> Store<K> where K: AsRef<[u8]> {
         })
     }
 
-    pub fn write<'env>(&mut self, env: &'env Rkv) -> Result<Writer<'env, K>, lmdb::Error> {
+    pub fn write<'env>(&self, env: &'env Rkv) -> Result<Writer<'env, K>, lmdb::Error> {
         let tx = env.write()?;
         Ok(Writer {
             tx: tx,

--- a/src/readwrite.rs
+++ b/src/readwrite.rs
@@ -114,6 +114,8 @@ impl<K> Store<K> where K: AsRef<[u8]> {
         })
     }
 
+    /// Note: there may be only one write transaction active at any given time,
+    /// so this will block if any other writers currently exist for this store.
     pub fn write<'env>(&self, env: &'env Rkv) -> Result<Writer<'env, K>, lmdb::Error> {
         let tx = env.write()?;
         Ok(Writer {


### PR DESCRIPTION
`Store.write()` requires its `&self` argument to be mutable, but it isn't clear why, since `Store` is a "wrapper around an `lmdb::Database`," and it seems like those are intended to be long-lived and used by both read-only and read-write transactions, per [LMDB > Getting Started](http://www.lmdb.tech/doc/starting.html), which states:

> Generally databases should only be opened once, by the first transaction in the process. After the first transaction completes, the database handles can freely be used by all subsequent transactions.

Nor do I see anything about the Store abstraction that suggests that it needs to impose this additional constraint to support a more humane API. Although I'm new to this codebase (and Rust more generally), so I might be missing something!

Presumably it's better to reuse handles for perf, although it isn't clear how expensive it is to create them. In any case, here's a patch that removes the constraint. It passes tests (modulo warnings that a couple of Store instances no longer have to be mutable, so I've removed mutability from them).
