### PR TITLE
add test of canonical read before write on same Writer

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -242,6 +242,20 @@ mod tests {
     }
 
     #[test]
+    fn test_read_before_write() {
+        let root = TempDir::new("test_read_before_write").expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+        let k = Rkv::new(root.path()).expect("new succeeded");
+        let sk: Store<&str> = k.create_or_open("sk").expect("opened");
+
+        let mut writer = sk.write(&k).expect("writer");
+        let _existing_value = writer.get("foo").expect("read");
+        // insert business logic here
+        writer.put("foo", &Value::I64(1234)).expect("wrote");
+        writer.commit().expect("committed");
+    }
+
+    #[test]
     fn test_concurrent_read_transactions_prohibited() {
         let root = TempDir::new("test_concurrent_reads_prohibited").expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");

--- a/src/env.rs
+++ b/src/env.rs
@@ -269,6 +269,23 @@ mod tests {
     }
 
     #[test]
+    fn test_read_before_write_str() {
+        let root = TempDir::new("test_read_before_write_str").expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+        let k = Rkv::new(root.path()).expect("new succeeded");
+        let sk: Store<&str> = k.create_or_open("sk").expect("opened");
+
+        let mut writer = sk.write(&k).expect("writer");
+        let mut existing = match writer.get("foo").expect("read") {
+            Some(Value::Str(val)) => val,
+            _ => "",
+        }.to_string();
+        existing.push('…');
+        writer.put("foo", &Value::Str(&existing)).expect("write");
+        writer.commit().expect("commit");
+    }
+
+    #[test]
     fn test_concurrent_read_transactions_prohibited() {
         let root = TempDir::new("test_concurrent_reads_prohibited").expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");


### PR DESCRIPTION
With key-value stores, a common pattern is to read a value from the database for a given key, apply some business logic (potentially transforming the value), and then to write a new value to the database for that key.

When I try that with rkv, using the same Writer to first read and then write the value, I hit two errors that are unexpected:

```
error[E0502]: cannot borrow `writer` as mutable because it is also borrowed as immutable
   --> src/env.rs:254:9
    |
252 |         let _existing_value = writer.get("foo").expect("read");
    |                               ------ immutable borrow occurs here
253 |         // insert business logic here
254 |         writer.put("foo", &Value::I64(1234)).expect("wrote");
    |         ^^^^^^ mutable borrow occurs here
255 |         writer.commit().expect("committed");
256 |     }
    |     - immutable borrow ends here

error[E0505]: cannot move out of `writer` because it is borrowed
   --> src/env.rs:255:9
    |
252 |         let _existing_value = writer.get("foo").expect("read");
    |                               ------ borrow of `writer` occurs here
...
255 |         writer.commit().expect("committed");
    |         ^^^^^^ move out of `writer` occurs here
```

Perhaps my implementation is naive, or maybe rkv doesn't support its approach for good reason. Regardless, it'd be useful to include a test for the conventional way to do this.
