### PR TITLE
implement deletion from store

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -277,7 +277,7 @@ mod tests {
             writer.commit().expect("committed");
         }
 
-        // Committed. Reads will succeed.
+        // Committed. Reads will succeed but return None to indicate a missing value.
         {
             let r = &k.read().unwrap();
             assert_eq!(sk.get(r, "foo").expect("read"), None);

--- a/src/env.rs
+++ b/src/env.rs
@@ -352,4 +352,18 @@ mod tests {
         let reader = s.read(&k).expect("reader");
         assert_eq!(reader.get("foo").expect("read"), Some(Value::I64(999)));
     }
+
+    #[test]
+    #[should_panic(expected = "not yet implemented")]
+    fn test_delete_value() {
+        let root = TempDir::new("test_delete_value").expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+        let k = Rkv::new(root.path()).expect("new succeeded");
+        let sk: Store<&str> = k.create_or_open_with_flags("sk", lmdb::DUP_SORT).expect("opened");
+
+        let mut writer = sk.write(&k).expect("writer");
+        writer.put("foo", &Value::I64(1234)).expect("wrote");
+        writer.put("foo", &Value::I64(1235)).expect("wrote");
+        writer.delete_value("foo", &Value::I64(1234)).expect("deleted");
+    }
 }

--- a/src/readwrite.rs
+++ b/src/readwrite.rs
@@ -71,11 +71,19 @@ impl<'env, K> Writer<'env, K> where K: AsRef<[u8]> {
             .map_err(StoreError::LmdbError)
     }
 
-    // TODO: duplicate data
     pub fn delete<'s>(&'s mut self, k: K) -> Result<(), StoreError> {
         self.tx
             .del(self.db, &k.as_ref(), None)
             .map_err(StoreError::LmdbError)
+    }
+
+    pub fn delete_value<'s>(&'s mut self, _k: K, _v: &Value) -> Result<(), StoreError> {
+        // Even better would be to make this a method only on a dupsort store —
+        // it would need a little bit of reorganizing of types and traits,
+        // but when I see "If the database does not support sorted duplicate
+        // data items (MDB_DUPSORT) the data parameter is ignored" in the docs,
+        // I see a footgun that we can avoid by using the type system.
+        unimplemented!();
     }
 
     pub fn commit(self) -> Result<(), StoreError> {

--- a/src/readwrite.rs
+++ b/src/readwrite.rs
@@ -71,6 +71,13 @@ impl<'env, K> Writer<'env, K> where K: AsRef<[u8]> {
             .map_err(StoreError::LmdbError)
     }
 
+    // TODO: duplicate data
+    pub fn delete<'s>(&'s mut self, k: K) -> Result<(), StoreError> {
+        self.tx
+            .del(self.db, &k.as_ref(), None)
+            .map_err(StoreError::LmdbError)
+    }
+
     pub fn commit(self) -> Result<(), StoreError> {
         self.tx.commit().map_err(StoreError::LmdbError)
     }


### PR DESCRIPTION
@rnewman: an API question here is whether to be consistent with the abbreviated method name [RwTransaction.del](https://docs.rs/lmdb/0.8.0/lmdb/struct.RwTransaction.html#method.del)—which is itself consistent with the underlying function name [mdb_del](https://docs.rs/lmdb-sys/0.8.0/lmdb_sys/fn.mdb_del.html)—or use the complete word *delete* as the name of the Writer method.

I've opted for the latter, as this is intended to be a humane interface, and humans usually speak in complete words. A minor consideration is that *del* may encourage [horizontal alignment](https://google.github.io/styleguide/javaguide.html#s4.6.3-horizontal-alignment) with consecutive *get* and *put* calls, which is arguably harmful (although also orthogonal and perhaps not something about which this library should have an opinion).

Regardless, the decision to call this *delete* was based on a weak opinion, weakly held, and I'm happy to rename it to *del* if you prefer.
