### PR TITLE
make Manager consumable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ backtrace = ["failure/backtrace", "failure/std"]
 [dependencies]
 arrayref = "0.3"
 bincode = "0.9"
+lazy_static = "1.0"
 lmdb = "0.7"
 ordered-float = "0.5"
 uuid = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 
 #[macro_use] extern crate arrayref;
 #[macro_use] extern crate failure;
+#[macro_use] extern crate lazy_static;
 
 extern crate bincode;
 extern crate lmdb;
@@ -48,7 +49,7 @@ pub use integer::{
 };
 
 pub use manager::{
-    Manager,
+    MANAGER,
 };
 
 pub use readwrite::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub use integer::{
 };
 
 pub use manager::{
-    MANAGER,
+    Manager
 };
 
 pub use readwrite::{

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -82,8 +82,7 @@ impl Manager {
     where F: FnOnce(&Path, c_uint) -> Result<Rkv, StoreError>,
           P: Into<&'p Path> {
         let canonical = path.into().canonicalize()?;
-        let mut map = self.stores.lock().unwrap();
-        Ok(match map.entry(canonical) {
+        Ok(match self.stores.entry(canonical) {
             Entry::Occupied(e) => e.get().clone(),
             Entry::Vacant(e) => {
                 let k = Arc::new(RwLock::new(f(e.key().as_path(), capacity)?));

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -40,7 +40,7 @@ pub struct Manager {
 }
 
 impl Manager {
-    fn new() -> Manager {
+    pub fn new() -> Manager {
         Manager {
             stores: Mutex::new(Default::default()),
         }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -39,7 +39,7 @@ use ::Rkv;
 /// A process is only permitted to have one open handle to each database. This manager
 /// exists to enforce that constraint: don't open databases directly.
 lazy_static! {
-    pub static ref MANAGER: RwLock<Manager> = {
+    static ref MANAGER: RwLock<Manager> = {
         RwLock::new(Manager::new())
     };
 }
@@ -53,6 +53,10 @@ impl Manager {
         Manager {
             stores: Default::default(),
         }
+    }
+
+    pub fn singleton() -> &'static RwLock<Manager> {
+        &*MANAGER
     }
 
     /// Return the open store at `path`, returning `None` if it has not already been opened.

--- a/tests/manager.rs
+++ b/tests/manager.rs
@@ -1,3 +1,13 @@
+// Copyright 2018 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
 extern crate rkv;
 extern crate tempdir;
 

--- a/tests/manager.rs
+++ b/tests/manager.rs
@@ -12,7 +12,7 @@ extern crate rkv;
 extern crate tempdir;
 
 use rkv::{
-	MANAGER,
+	Manager,
 	Rkv,
 };
 
@@ -32,9 +32,9 @@ fn test_same() {
     fs::create_dir_all(root.path()).expect("dir created");
 
     let p = root.path();
-    assert!(MANAGER.read().unwrap().get(p).expect("success").is_none());
+    assert!(Manager::singleton().read().unwrap().get(p).expect("success").is_none());
 
-    let created_arc = MANAGER.write().unwrap().get_or_create(p, Rkv::new).expect("created");
-    let fetched_arc = MANAGER.read().unwrap().get(p).expect("success").expect("existed");
+    let created_arc = Manager::singleton().write().unwrap().get_or_create(p, Rkv::new).expect("created");
+    let fetched_arc = Manager::singleton().read().unwrap().get(p).expect("success").expect("existed");
     assert!(Arc::ptr_eq(&created_arc, &fetched_arc));
 }

--- a/tests/manager.rs
+++ b/tests/manager.rs
@@ -2,7 +2,7 @@ extern crate rkv;
 extern crate tempdir;
 
 use rkv::{
-	Manager,
+	MANAGER,
 	Rkv,
 };
 
@@ -16,17 +16,15 @@ use std::sync::{
 
 #[test]
 // Identical to the same-named unit test, but this one confirms that it works
-// via public Manager APIs.
+// via the public MANAGER singleton.
 fn test_same() {
-    let root = TempDir::new("test_same").expect("tempdir");
+    let root = TempDir::new("test_same_singleton").expect("tempdir");
     fs::create_dir_all(root.path()).expect("dir created");
 
-    let mut manager = Manager::new();
-
     let p = root.path();
-    assert!(manager.get(p).expect("success").is_none());
+    assert!(MANAGER.read().unwrap().get(p).expect("success").is_none());
 
-    let created_arc = manager.get_or_create(p, Rkv::new).expect("created");
-    let fetched_arc = manager.get(p).expect("success").expect("existed");
+    let created_arc = MANAGER.write().unwrap().get_or_create(p, Rkv::new).expect("created");
+    let fetched_arc = MANAGER.read().unwrap().get(p).expect("success").expect("existed");
     assert!(Arc::ptr_eq(&created_arc, &fetched_arc));
 }

--- a/tests/manager.rs
+++ b/tests/manager.rs
@@ -1,0 +1,32 @@
+extern crate rkv;
+extern crate tempdir;
+
+use rkv::{
+	Manager,
+	Rkv,
+};
+
+use self::tempdir::TempDir;
+
+use std::fs;
+
+use std::sync::{
+    Arc,
+};
+
+#[test]
+// Identical to the same-named unit test, but this one confirms that it works
+// via public Manager APIs.
+fn test_same() {
+    let root = TempDir::new("test_same").expect("tempdir");
+    fs::create_dir_all(root.path()).expect("dir created");
+
+    let mut manager = Manager::new();
+
+    let p = root.path();
+    assert!(manager.get(p).expect("success").is_none());
+
+    let created_arc = manager.get_or_create(p, Rkv::new).expect("created");
+    let fetched_arc = manager.get(p).expect("success").expect("existed");
+    assert!(Arc::ptr_eq(&created_arc, &fetched_arc));
+}


### PR DESCRIPTION
@rnewman `Manager::new` would have to be *pub* in order for a consumer to use it to create a Manager instance that manages database handles for them. But perhaps you have a different plan for how consumers should use Manager?

I suppose it somewhat begs the question to enable consumers to instantiate them directly, since a consumer can then evade the constraint that Manager imposes by instantiating it multiple times. One alternative would be to create a Manager singleton via a lazy static, i.e. something like:

```rust

#[macro_use]
extern crate lazy_static;

lazy_static! {
    #[derive(Debug)]
    static ref MANAGER: Manager = {
        Manager::new()
    };
}
```

Then keep `Manager::new()` private to force consumers to get or create Rkv instances via the singleton.
