### PR TITLE
implement Value::Blob type (fixes #20)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,5 @@ default_features = false
 features = ["derive"]
 
 [dev-dependencies]
+byteorder = "1"
 tempdir = "0.3"

--- a/src/value.rs
+++ b/src/value.rs
@@ -38,6 +38,7 @@ pub enum Type {
     Uuid    = 6,
     Str     = 7,
     Json    = 8,
+    Blob    = 9,
 }
 
 /// We use manual tagging, because <https://github.com/serde-rs/serde/issues/610>.
@@ -60,6 +61,7 @@ impl Type {
             6 => Some(Type::Uuid),
             7 => Some(Type::Str),
             8 => Some(Type::Json),
+            9 => Some(Type::Blob),
             _ => None,
         }
     }
@@ -76,6 +78,7 @@ impl ::std::fmt::Display for Type {
             Type::Uuid    => "uuid",
             Type::Str     => "str",
             Type::Json    => "json",
+            Type::Blob    => "blob",
         })
     }
 }
@@ -90,6 +93,7 @@ pub enum Value<'s> {
     Uuid(&'s UuidBytes),
     Str(&'s str),
     Json(&'s str),
+    Blob(&'s [u8]),
 }
 
 // TODO: implement conversion between the two types of `Value` wrapper.
@@ -103,6 +107,7 @@ enum OwnedValue {
     Uuid(Uuid),
     Str(String),
     Json(String),    // TODO
+    Blob(Vec<u8>),
 }
 
 fn uuid<'s>(bytes: &'s [u8]) -> Result<Value<'s>, DataError> {
@@ -157,6 +162,9 @@ impl<'s> Value<'s> {
             Type::Json => {
                 deserialize(data).map(Value::Json)
             },
+            Type::Blob => {
+                deserialize(data).map(Value::Blob)
+            },
             Type::Uuid => {
                 // Processed above to avoid verbose duplication of error transforms.
                 unreachable!()
@@ -186,6 +194,9 @@ impl<'s> Value<'s> {
             },
             &Value::Json(ref v) => {
                 serialize(&(Type::Json.to_tag(), v), Infinite)
+            },
+            &Value::Blob(ref v) => {
+                serialize(&(Type::Blob.to_tag(), v), Infinite)
             },
             &Value::Uuid(ref v) => {
                 // Processed above to avoid verbose duplication of error transforms.


### PR DESCRIPTION
Here's an implementation of Value::Blob along with tests of round-tripping both a [u8] and a [u16] that we convert to [u8] beforehand and convert back afterward. (Arguably the latter is more a test of the conversion functions than rkv itself, but it's useful documentation for developers who want to use rkv to store similar data.)

@fluffyemily Perhaps you can review this one?
