### PR TITLE
implement iteration from start of store or specified key (fixes #23)

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -518,6 +518,17 @@ mod tests {
         assert_eq!(str::from_utf8(key).expect("key"), "你好，遊客");
         assert_eq!(val.expect("value"), Some(Value::Str("米克規則")));
         assert!(iter.next().is_none());
+
+        // Reader.iter_from() works as expected when the given key is a prefix
+        // of a key in the store.
+        let mut iter = reader.iter_from("no").unwrap();
+        let (key, val) = iter.next().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "noo");
+        assert_eq!(val.expect("value"), Some(Value::F64(1234.0.into())));
+        let (key, val) = iter.next().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "你好，遊客");
+        assert_eq!(val.expect("value"), Some(Value::Str("米克規則")));
+        assert!(iter.next().is_none());
     }
 
     #[test]

--- a/src/env.rs
+++ b/src/env.rs
@@ -145,9 +145,19 @@ mod tests {
     extern crate tempdir;
     extern crate byteorder;
 
-    use self::byteorder::{ByteOrder, LittleEndian};
-    use self::tempdir::TempDir;
-    use std::{fs, str};
+    use self::byteorder::{
+        ByteOrder,
+        LittleEndian,
+    };
+
+    use self::tempdir::{
+        TempDir,
+    };
+
+    use std::{
+        fs,
+        str,
+    };
 
     use super::*;
     use ::*;

--- a/src/env.rs
+++ b/src/env.rs
@@ -467,7 +467,7 @@ mod tests {
         // An iterator over an empty store returns no values.
         {
             let reader = sk.read(&k).unwrap();
-            let mut iter = reader.iter().unwrap();
+            let mut iter = reader.iter_start().unwrap();
             assert!(iter.next().is_none());
         }
 
@@ -483,7 +483,7 @@ mod tests {
         let reader = sk.read(&k).unwrap();
 
         // Reader.iter() returns (key, value) tuples ordered by key.
-        let mut iter = reader.iter().unwrap();
+        let mut iter = reader.iter_start().unwrap();
         let (key, val) = iter.next().unwrap();
         assert_eq!(str::from_utf8(key).expect("key"), "bar");
         assert_eq!(val.expect("value"), Some(Value::Bool(true)));

--- a/src/env.rs
+++ b/src/env.rs
@@ -476,6 +476,8 @@ mod tests {
         writer.put("noo", &Value::F64(1234.0.into())).expect("wrote");
         writer.put("bar", &Value::Bool(true)).expect("wrote");
         writer.put("baz", &Value::Str("héllo, yöu")).expect("wrote");
+        writer.put("héllò, töűrîst", &Value::Str("Emil.RuleZ!")).expect("wrote");
+        writer.put("你好，遊客", &Value::Str("米克規則")).expect("wrote");
         writer.commit().expect("committed");
 
         let reader = sk.read(&k).unwrap();
@@ -492,8 +494,14 @@ mod tests {
         assert_eq!(str::from_utf8(key).expect("key"), "foo");
         assert_eq!(val.expect("value"), Some(Value::I64(1234)));
         let (key, val) = iter.next().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "héllò, töűrîst");
+        assert_eq!(val.expect("value"), Some(Value::Str("Emil.RuleZ!")));
+        let (key, val) = iter.next().unwrap();
         assert_eq!(str::from_utf8(key).expect("key"), "noo");
         assert_eq!(val.expect("value"), Some(Value::F64(1234.0.into())));
+        let (key, val) = iter.next().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "你好，遊客");
+        assert_eq!(val.expect("value"), Some(Value::Str("米克規則")));
         assert!(iter.next().is_none());
 
         // Iterators don't loop.  Once one returns None, additional calls
@@ -501,12 +509,14 @@ mod tests {
         assert!(iter.next().is_none());
 
         // Reader.iter_from() begins iteration at the first key equal to
-        // or greater than the given key.  In this case, the first (and only)
-        // key greater than "moo" is "noo", so that's the only result.
+        // or greater than the given key.
         let mut iter = reader.iter_from("moo").unwrap();
         let (key, val) = iter.next().unwrap();
         assert_eq!(str::from_utf8(key).expect("key"), "noo");
         assert_eq!(val.expect("value"), Some(Value::F64(1234.0.into())));
+        let (key, val) = iter.next().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "你好，遊客");
+        assert_eq!(val.expect("value"), Some(Value::Str("米克規則")));
         assert!(iter.next().is_none());
     }
 

--- a/src/readwrite.rs
+++ b/src/readwrite.rs
@@ -113,7 +113,7 @@ impl<'env, K> Reader<'env, K> where K: AsRef<[u8]> {
         self.tx.abort();
     }
 
-    pub fn iter<'s>(&'s self) -> Result<Iter<'s>, StoreError> {
+    pub fn iter_start<'s>(&'s self) -> Result<Iter<'s>, StoreError> {
         let mut cursor = self.tx.open_ro_cursor(self.db).map_err(StoreError::LmdbError)?;
         let iter = cursor.iter();
         Ok(Iter {


### PR DESCRIPTION
This implements read-only iteration of `(key, value)` tuples from the start of the store or from a specified key, fixing #23 and providing a useful, humane subset of the functionality provided by LMDB cursors, which are abstracted away by this interface (one requests an _Iter_ directly from a _Reader_ without indirecting through a _Cursor_). Keys are `&[u8]`, while Values are _Value_ instances.

The _Reader.iter()_ and _Reader.iter_from()_ methods are analogous to the same-named methods of LMDB's [RoCursor](https://docs.rs/lmdb/0.8.0/lmdb/struct.RoCursor.html). An alternate interface would be a single _Reader.iter()_ method that accepts an _Option<AsRef<[u8]>_, which can be `None` (to iterate from the start of the store) or `Some(AsRef<[u8])` to start from that key. It wasn't clear which interface would be more ergonomic or idiomatic, however, and I defaulted to the one that is similar to LMDB's. I'm happy to reconsider (or consider a third alternative).

I discovered an issue in LMDB while developing this changeset and requested upstream pulls https://github.com/danburkert/lmdb-rs/pull/29 and https://github.com/danburkert/lmdb-rs/pull/30. They don't block landing this changeset, they'll just make it more humane by preventing a panic if you call _Reader.iter_from()_ on a key greater than any key in the store. We should update the minimum required version of LMDB once that lands upstream.

@rnewman I recall that you're around this week, so I'm requesting review from you, but please feel free to redirect to @ncalexan or @fluffyemily, both of whom have been reviewing in your stead, if you'd rather they review it.
