### PR TITLE
update version for release to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rkv"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Richard Newman <rnewman@twinql.com>"]
 description = "A humane key-value store built on LMDB."
 license = "Apache-2.0"


### PR DESCRIPTION
We should publish a new release, as we've landed several features recently, including the Manager, iteration, and Value::Blob, the latter of which deserves a version bump per @rnewman's comment in #20.